### PR TITLE
Fix test description typo

### DIFF
--- a/test/robot_race/game_test.exs
+++ b/test/robot_race/game_test.exs
@@ -99,7 +99,7 @@ defmodule RobotRace.GameTest do
       assert [%Robot{score: 0}] = Game.robots(game)
     end
 
-    test "scores points and tranistions to finished", %{bender: bender} do
+    test "scores points and transitions to finished", %{bender: bender} do
       game = Game.new(%GameConfig{winning_score: 1})
       {:ok, game} = Game.join(game, bender)
       game = Game.play(game)


### PR DESCRIPTION
## Summary
- fix typo in RobotRace.GameTest description

## Testing
- `mix deps.get` *(fails: Could not find Hex)*
- `mix test` *(fails: Could not find Hex)*

------
https://chatgpt.com/codex/tasks/task_e_6842aa253be08332994ad0a93a52ea93