### PR TITLE
Fix interval comment

### DIFF
--- a/lib/robot_race_web/live/lobby_live.ex
+++ b/lib/robot_race_web/live/lobby_live.ex
@@ -9,7 +9,7 @@ defmodule RobotRaceWeb.LobbyLive do
 
   # Simulation constants
   @winning_score 25
-  # Run simulation steps every 1000ms (1 second)
+  # Run simulation steps every 200ms (0.2 seconds)
   @simulation_interval 200
 
   @impl Phoenix.LiveView


### PR DESCRIPTION
## Summary
- update the simulation interval comment to match the actual value
- run `mix format`

## Testing
- `mix deps.get` *(fails: Could not find Hex)*
- `mix compile` *(fails: Could not find Hex)*
- `mix test` *(fails: Could not find an SCM for dependency :phoenix)*
- `mix lint` *(fails: Could not find Hex)*
- `mix format` *(fails: Could not find Hex)*
- `mix assets.deploy` *(fails: Could not find Hex)*

------
https://chatgpt.com/codex/tasks/task_e_6842ac5aec8c8332aaef68129fd10560